### PR TITLE
Update customize

### DIFF
--- a/customize
+++ b/customize
@@ -57,9 +57,11 @@ cp /root/nginx.conf /opt/local/etc/nginx/nginx.conf
 cp /root/php.ini /opt/local/etc/php.ini
 
 chown -R www:www /opt/local/www
-chown www:www /opt/local/etc/nginx/sites-enabled
-chown www:www /opt/local/etc/nginx/sites-available
-chown www:www /var/db/ssl
+chown root:root /opt/local/etc/nginx/sites-enabled
+chown root:root /opt/local/etc/nginx/sites-available
+chmod -R a+r /opt/local/etc/nginx/sites-enabled
+chmod -R a+r /opt/local/etc/nginx/sites-available
+chown root:root /var/db/ssl
 
 # ln -s /opt/local/etc/nginx/sites-available/wordpress-ssl.conf /opt/local/etc/nginx/sites-enabled/
 ln -s /opt/local/etc/nginx/sites-available/wordpress.conf /opt/local/etc/nginx/sites-enabled/

--- a/customize
+++ b/customize
@@ -62,6 +62,8 @@ chown root:root /opt/local/etc/nginx/sites-available
 chmod -R a+r /opt/local/etc/nginx/sites-enabled
 chmod -R a+r /opt/local/etc/nginx/sites-available
 chown root:root /var/db/ssl
+find /var/db/ssl -type d | xargs chmod 700
+find /var/db/ssl -type f | xargs chmod 600
 
 # ln -s /opt/local/etc/nginx/sites-available/wordpress-ssl.conf /opt/local/etc/nginx/sites-enabled/
 ln -s /opt/local/etc/nginx/sites-available/wordpress.conf /opt/local/etc/nginx/sites-enabled/


### PR DESCRIPTION
bad idea to give permissions on nginx configuration files to www user. Nginx runs from root user.
Same permissions for /var/db/ssl
````[root@test ~]# ps -Af | grep nginx 
     root  9076  3882   0   Nov 03 ?           0:00 /opt/local/sbin/nginx -c /opt/local/etc/nginx/nginx.conf
     www  9078  9076   0   Nov 03 ?           0:15 /opt/local/sbin/nginx -c /opt/local/etc/nginx/nginx.conf
     www  9079  9076   0   Nov 03 ?           0:17 /opt/local/sbin/nginx -c /opt/local/etc/nginx/nginx.conf
     www  9077  9076   0   Nov 03 ?           0:15 /opt/local/sbin/nginx -c /opt/local/etc/nginx/nginx.conf
     www  9080  9076   0   Nov 03 ?           0:16 /opt/local/sbin/nginx -c /opt/local/etc/nginx/nginx.conf
     www  9081  9076   0   Nov 03 ?           0:01 /opt/local/sbin/nginx -c /opt/local/etc/nginx/nginx.conf

```
```
